### PR TITLE
Cleanup pull request saturation code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     </table>
   </div>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/bluebird/2.9.13/bluebird.min.js"></script>
   <script src="js/main.js"></script>
   <script type="text/javascript">
     var urlMatches = location.href.match(/apiUrl=([^&]*)/);


### PR DESCRIPTION
Rather than using jquery's unusual deferred library, I added a real Promise library (in the form of [bluebird](https://github.com/petkaantonov/bluebird/) so that we can properly do things like `Promise.map`.  In particular, this allows the `getRepoPull` and `getRepoPulls` methods to do the full saturation of pull request data (comments, commits, and statuses) which helps simplify the calling code.