### PR TITLE
Allow user to enter organization name instead of repositories.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,7 +24,6 @@
         });
       }
     );
-
   }
 
   GhApi.prototype.getRepoPull = function(repoPath, prNum) {

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,10 @@
     return Promise.resolve($.ajax(this.apiUrl + '/repos/' + repoPath + '/commits/master'));
   }
 
+  GhApi.prototype.getOrganizationRepos = function(organization) {
+    return Promise.resolve($.ajax(this.apiUrl + '/orgs/' + organization + '/repos'));
+  };
+
   GhApi.prototype.getRepoPulls = function(repoPath) {
     var self = this;
 
@@ -95,9 +99,15 @@
     );
   }
 
-  function parseRepos(ghApi, repoPaths) {
-    $.each(repoPaths, function(index, repoPath) {
-      parsePullRequests(ghApi, repoPath);
+  function parseRepos(ghApi, specs) {
+    $.each(specs, function(index, spec) {
+      if (spec.indexOf('/') === -1) {
+        ghApi.getOrganizationRepos(spec).each(function(repo) {
+          parsePullRequests(ghApi, repo.full_name);
+        });
+      } else {
+        parsePullRequests(ghApi, spec);
+      }
     });
   }
 

--- a/js/main.js
+++ b/js/main.js
@@ -96,11 +96,9 @@
   }
 
   function parseRepos(ghApi, repoPaths) {
-    if (repoPaths.indexOf(repoPath) == -1) {
-      $.each(repoPaths, function(index, repoPath) {
-        parsePullRequests(ghApi, repoPath);
-      });
-    }
+    $.each(repoPaths, function(index, repoPath) {
+      parsePullRequests(ghApi, repoPath);
+    });
   }
 
   function parseAllPullRequests(user, commit, pulls) {


### PR DESCRIPTION
Rather than requiring the user to enter every single repository for an organization (and continue to do so to keep it up-to-date), allow just the organization name to be entered.  All of the organizations repositories will be looked up and all of the pull requests for each of them will be shown.